### PR TITLE
Added new methods using Mqtt.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -86,7 +86,7 @@ declare module '@xaviabot/fca-unofficial' {
         changeThreadColor: (color: string, threadID: string, callback?: (err?: Error) => void) => Promise<void>,
         changeThreadEmoji: (emoji: string | null, threadID: string, callback?: (err?: Error) => void) => Promise<void>,
         createNewGroup: (participantIDs: string[], groupTitle?: string, callback?: (err: Error, threadID: string) => void) => Promise<string>,
-        createPoll: (title: string, threadID: string, options?: { [item: string]: boolean }, callback?: (err?: Error) => void) => Promise<void>,
+        createPoll: (title: string, options?: { [item: string]: boolean }, threadID: string, callback?: (err?: Error) => void) => Promise<void>,
         deleteMessage: (messageOrMessages: string | string[], callback?: (err?: Error) => void) => Promise<void>,
         deleteThread: (threadOrThreads: string | string[], callback?: (err?: Error) => void) => Promise<void>,
         forwardAttachment: (attachmentID: string, userOrUsers: string | string[], callback?: (err?: Error) => void) => Promise<void>,
@@ -120,7 +120,10 @@ declare module '@xaviabot/fca-unofficial' {
         setOptions: (options: Partial<IFCAU_Options>) => void,
         setTitle: (newTitle: string, threadID: string, callback?: (err?: Error) => void) => Promise<void>,
         unsendMessage: (messageID: string, callback?: (err?: Error) => void) => Promise<void>,
-	editMessage: (text: string, messageID: string, callback?: (err?: Error) => void) => Promise<void>
+	    editMessage: (text: string, messageID: string, callback?: (err?: Error) => void) => Promise<void>,
+        setMessageReactionMqtt: (reaction: string, messageID: string, threadID: string, callback?: (err?: Error) => void) => Promise<void>,
+        pinMessage: (pinMode: boolean, messageID: string, threadID: string, callback?: (err?: Error) => void) => Promise<void>,
+        forwardMessage: (messageID: string, threadID: string, callback?: (err?: Error) => void) => Promise<void>,
     }
 
     export type IFCAU_ListenMessage =

--- a/index.js
+++ b/index.js
@@ -244,6 +244,9 @@ function buildAPI(globalOptions, html, jar) {
         "unsendMessage",
         "unfriend",
         "editMessage",
+        "setMessageReactionMqtt",
+        "pinMessage",
+        "forwardMessage",
 
         // HTTP
         "httpGet",

--- a/src/createPoll.js
+++ b/src/createPoll.js
@@ -1,71 +1,56 @@
-"use strict";
+'use strict';
 
-var utils = require("../utils");
-var log = require("npmlog");
+const { generateOfflineThreadingID, getCurrentTimestamp } = require('../utils');
 
-module.exports = function(defaultFuncs, api, ctx) {
-  return function createPoll(title, threadID, options, callback) {
-    var resolveFunc = function(){};
-    var rejectFunc = function(){};
-    var returnPromise = new Promise(function (resolve, reject) {
-      resolveFunc = resolve;
-      rejectFunc = reject;
-    });
+function isCallable(func) {
+  try {
+    Reflect.apply(func, null, []);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
 
-    if (!callback) {
-      if (utils.getType(options) == "Function") {
-        callback = options;
-        options = null;
-      } else {
-        callback = function(err) {
-          if (err) {
-            return rejectFunc(err);
-          }
-          resolveFunc();
-        };
-      }
-    }
-    if (!options) {
-      options = {}; // Initial poll options are optional
+module.exports = function (defaultFuncs, api, ctx) {
+  return function createPoll(title, options, threadID, callback) {
+    if (!ctx.mqttClient) {
+      throw new Error('Not connected to MQTT');
     }
 
-    var form = {
-      target_id: threadID,
-      question_text: title
+    ctx.wsReqNumber += 1;
+    ctx.wsTaskNumber += 1;
+
+    const taskPayload = {
+      question_text: title,
+      thread_key: threadID,
+      options: options,
+      sync_group: 1,
     };
 
-    // Set fields for options (and whether they are selected initially by the posting user)
-    var ind = 0;
-    for (var opt in options) {
-      // eslint-disable-next-line no-prototype-builtins
-      if (options.hasOwnProperty(opt)) {
-        form["option_text_array[" + ind + "]"] = opt;
-        form["option_is_selected_array[" + ind + "]"] = options[opt]
-          ? "1"
-          : "0";
-        ind++;
-      }
+    const task = {
+      failure_count: null,
+      label: '163',
+      payload: JSON.stringify(taskPayload),
+      queue_name: 'poll_creation',
+      task_id: ctx.wsTaskNumber,
+    };
+
+    const content = {
+      app_id: '2220391788200892',
+      payload: JSON.stringify({
+        data_trace_id: null,
+        epoch_id: parseInt(generateOfflineThreadingID()),
+        tasks: [task],
+        version_id: '7158486590867448',
+      }),
+      request_id: ctx.wsReqNumber,
+      type: 3,
+    };
+
+    if (isCallable(callback)) {
+      ctx.reqCallbacks[ctx.wsReqNumber] = callback;
     }
 
-    defaultFuncs
-      .post(
-        "https://www.facebook.com/messaging/group_polling/create_poll/?dpr=1",
-        ctx.jar,
-        form
-      )
-      .then(utils.parseAndCheckLogin(ctx, defaultFuncs))
-      .then(function(resData) {
-        if (resData.payload.status != "success") {
-          throw resData;
-        }
-
-        return callback();
-      })
-      .catch(function(err) {
-        log.error("createPoll", err);
-        return callback(err);
-      });
-
-    return returnPromise;
+    ctx.mqttClient.publish('/ls_req', JSON.stringify(content), { qos: 1, retain: false });
   };
 };

--- a/src/forwardMessage.js
+++ b/src/forwardMessage.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const { generateOfflineThreadingID, getCurrentTimestamp } = require('../utils');
+
+function isCallable(func) {
+  try {
+    Reflect.apply(func, null, []);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+module.exports = function (defaultFuncs, api, ctx) {
+  return function forwardMessage(messageID, threadID, callback) {
+    if (!ctx.mqttClient) {
+      throw new Error('Not connected to MQTT');
+    }
+
+    ctx.wsReqNumber += 1;
+    ctx.wsTaskNumber += 1;
+
+    const taskPayload = {
+      thread_id: threadID,
+      otid: parseInt(generateOfflineThreadingID()),
+      source: 65544,
+      send_type: 5,
+      sync_group: 1,
+      forwarded_msg_id: messageID,
+      strip_forwarded_msg_caption: 0,
+      initiating_source: 1,
+    };
+
+    const task = {
+      failure_count: null,
+      label: '46',
+      payload: JSON.stringify(taskPayload),
+      queue_name: `${threadID}`,
+      task_id: ctx.wsTaskNumber,
+    };
+
+    const content = {
+      app_id: '2220391788200892',
+      payload: JSON.stringify({
+        data_trace_id: null,
+        epoch_id: parseInt(generateOfflineThreadingID()),
+        tasks: [task],
+        version_id: '25095469420099952',
+      }),
+      request_id: ctx.wsReqNumber,
+      type: 3,
+    };
+
+    if (isCallable(callback)) {
+      ctx.reqCallbacks[ctx.wsReqNumber] = callback;
+    }
+
+    ctx.mqttClient.publish('/ls_req', JSON.stringify(content), { qos: 1, retain: false });
+  };
+};

--- a/src/pinMessage.js
+++ b/src/pinMessage.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const { generateOfflineThreadingID, getCurrentTimestamp } = require('../utils');
+
+function isCallable(func) {
+  try {
+    Reflect.apply(func, null, []);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+module.exports = function (defaultFuncs, api, ctx) {
+  return function pinMessage(pinMode, messageID, threadID, callback) {
+    if (!ctx.mqttClient) {
+      throw new Error('Not connected to MQTT');
+    }
+
+    ctx.wsReqNumber += 1;
+    ctx.wsTaskNumber += 1;
+
+    const taskLabel = pinMode ? '430' : '431';
+    const queueNamePrefix = pinMode ? 'pin_msg_v2_' : 'unpin_msg_v2_';
+
+    const taskPayload = {
+      thread_key: threadID,
+      message_id: messageID,
+      timestamp_ms: getCurrentTimestamp(),
+    };
+
+    const task = {
+      failure_count: null,
+      label: taskLabel,
+      payload: JSON.stringify(taskPayload),
+      queue_name: `${queueNamePrefix}${threadID}`,
+      task_id: ctx.wsTaskNumber,
+    };
+
+    const content = {
+      app_id: '2220391788200892',
+      payload: JSON.stringify({
+        data_trace_id: null,
+        epoch_id: parseInt(generateOfflineThreadingID()),
+        tasks: [task],
+        version_id: '25095469420099952',
+      }),
+      request_id: ctx.wsReqNumber,
+      type: 3,
+    };
+
+    if (isCallable(callback)) {
+      ctx.reqCallbacks[ctx.wsReqNumber] = callback;
+    }
+
+    ctx.mqttClient.publish('/ls_req', JSON.stringify(content), { qos: 1, retain: false });
+  };
+};

--- a/src/setMessageReactionMqtt.js
+++ b/src/setMessageReactionMqtt.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const { generateOfflineThreadingID, getCurrentTimestamp } = require('../utils');
+
+function isCallable(func) {
+  try {
+    Reflect.apply(func, null, []);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+module.exports = function (defaultFuncs, api, ctx) {
+  return function setMessageReactionMqtt(reaction, messageID, threadID, callback) {
+    if (!ctx.mqttClient) {
+      throw new Error('Not connected to MQTT');
+    }
+
+    ctx.wsReqNumber += 1;
+    ctx.wsTaskNumber += 1;
+
+    const taskPayload = {
+      thread_key: threadID,
+      timestamp_ms: getCurrentTimestamp(),
+      message_id: messageID,
+      reaction: reaction,
+      actor_id: ctx.userID,
+      reaction_style: null,
+      sync_group: 1,
+      send_attribution: Math.random() < 0.5 ? 65537 : 524289
+    };
+
+    const task = {
+      failure_count: null,
+      label: '29',
+      payload: JSON.stringify(taskPayload),
+      queue_name: JSON.stringify(['reaction', messageID]),
+      task_id: ctx.wsTaskNumber,
+    };
+
+    const content = {
+      app_id: '2220391788200892',
+      payload: JSON.stringify({
+        data_trace_id: null,
+        epoch_id: parseInt(generateOfflineThreadingID()),
+        tasks: [task],
+        version_id: '7158486590867448',
+      }),
+      request_id: ctx.wsReqNumber,
+      type: 3,
+    };
+
+    if (isCallable(callback)) {
+      ctx.reqCallbacks[ctx.wsReqNumber] = callback;
+    }
+
+    ctx.mqttClient.publish('/ls_req', JSON.stringify(content), { qos: 1, retain: false });
+  };
+};

--- a/utils.js
+++ b/utils.js
@@ -120,6 +120,12 @@ function generateThreadingID(clientID) {
   return "<" + k + ":" + l + "-" + m + "@mail.projektitan.com>";
 }
 
+function getCurrentTimestamp() {
+  const date = new Date();
+  const unixTime = date.getTime();
+  return unixTime;
+}
+
 function binaryToDecimal(data) {
   var ret = "";
   while (data !== "0") {
@@ -1403,6 +1409,7 @@ module.exports = {
   decodeClientPayload,
   getAppState,
   getAdminTextMessageType,
-  setProxy
+  setProxy,
+  getCurrentTimestamp
 };
 


### PR DESCRIPTION
**Changes:**

- **createPoll:** Updated and fixed the `createPoll` function, enabling users to create polls within threads. This function accepts parameters for the title, options (an array, example: ['option-1', 'option-2',...]), thread ID, and a callback function.

- **pinMessage:** Implemented the `pinMessage` function, which allows users to pin messages within threads. Users can specify pinMode (true/false, where true pins and false unpins), message ID, thread ID, and an optional callback function to handle the response.

- **forwardMessage:** Added the `forwardMessage` function, enabling users to forward messages to other threads. This function accepts parameters for the target messageID (the ID of the message to be forwarded), thread ID (specify the thread you want to forward the message to), and an optional callback function.

- **setMessageReactionMqtt:** Users can specify the reaction (emoji of the reaction you want to set), message ID, thread ID, and an optional callback function.

**Testing:**

- Each function has been thoroughly tested locally to ensure proper functionality.
